### PR TITLE
feat: 미션 성공 로직 변경, HealthKit 수정

### DIFF
--- a/Pickle/Pickle/Screen/Home/MissionSettingView.swift
+++ b/Pickle/Pickle/Screen/Home/MissionSettingView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct TimeMissionSettingView: View {
     @EnvironmentObject var missionStore: MissionStore
     @Binding var timeMission: TimeMission
+    @Binding var status: Status
     
     var title: String
     @Binding var isTimeMissionSettingModalPresented: Bool
@@ -24,11 +25,13 @@ struct TimeMissionSettingView: View {
                     isTimeMissionSettingModalPresented.toggle()
                 } label: {
                     Text("취소")
+                        .font(.pizzaBody)
+                        .foregroundColor(.pickle)
                 }
                 Spacer()
                 
                 Text("\(title) 설정")
-                    .font(.pizzaTitle2Bold)
+                    .font(.nanumEbTitle)
                 Spacer()
                 
                 Button {
@@ -36,6 +39,8 @@ struct TimeMissionSettingView: View {
                     isTimeMissionSettingModalPresented.toggle()
                 } label: {
                     Text("저장")
+                        .font(.pizzaBody)
+                        .foregroundColor(.pickle)
                 }
             }
             .padding()
@@ -53,7 +58,7 @@ struct TimeMissionSettingView: View {
 
 struct MissionSettingView_Previews: PreviewProvider {
     static var previews: some View {
-        TimeMissionSettingView(timeMission: .constant(TimeMission(id: "")), title: "기상 미션",
+        TimeMissionSettingView(timeMission: .constant(TimeMission(id: "")), status: .constant(.ready), title: "기상 미션",
                                isTimeMissionSettingModalPresented: .constant(true))
     }
 }

--- a/Pickle/Pickle/Screen/Home/MissionStyleView.swift
+++ b/Pickle/Pickle/Screen/Home/MissionStyleView.swift
@@ -146,7 +146,6 @@ struct TimeMissionStyleView: View {
     @State private var isTimeMissionSettingModalPresented = false
     @Binding var showsAlert: Bool
     
-    private let currentTime: Date = Date()
     var buttonSwitch: Bool {
         switch status {
         case .ready, .done:
@@ -179,17 +178,13 @@ struct TimeMissionStyleView: View {
                     })
                     .sheet(isPresented: $isTimeMissionSettingModalPresented) {
                         TimeMissionSettingView(timeMission: $timeMission,
-                                               title: timeMission.title,
+                                               status: $status, title: timeMission.title,
                                                isTimeMissionSettingModalPresented: $isTimeMissionSettingModalPresented)
                         .presentationDetents([.fraction(0.4)])
                     }
             }
             
             Spacer(minLength: 10)
-            // 현재 시간과 목표 기상시간 비교
-            if currentTime > timeMission.wakeupTime.adding(minutes: -10) && currentTime < timeMission.wakeupTime.adding(minutes: 10) {
-                
-            }
             
             MissionButton(status: $status, action: {
                 status = .done
@@ -198,7 +193,10 @@ struct TimeMissionStyleView: View {
             .disabled(buttonSwitch)
         }
         .onAppear {
-            
+            missionComplet()
+        }
+        .refreshable {
+            missionComplet()
         }
         .padding(.horizontal, 20)
         .padding(.vertical, 20)
@@ -210,6 +208,15 @@ struct TimeMissionStyleView: View {
         .padding(.horizontal)
         .padding(.top, 15)
     }
+    
+    func missionComplet() {
+        // 현재 시간과 목표 기상시간 비교
+        if Date.now > timeMission.wakeupTime.adding(minutes: -10) && Date.now < timeMission.wakeupTime.adding(minutes: 10) {
+            status = .complete
+        } else {
+            status = .ready
+        }
+    }
 }
 
 struct BehaviorMissionStyleView: View {
@@ -218,7 +225,6 @@ struct BehaviorMissionStyleView: View {
     @Binding var status1: Status
     @Binding var status2: Status
     @Binding var status3: Status
-//    let testStep: Int = 5555
     
     @State private var isBehaviorMissionSettingModalPresented = false
     @Binding var showsAlert: Bool
@@ -328,12 +334,10 @@ struct BehaviorMissionStyleView: View {
             }
         }
         .onAppear {
-            healthKitStore.fetchStepCount()
-            missionComplete()
+            healthKitStore.fetchStepCount({ self.missionComplete() })
         }
         .refreshable {
-            healthKitStore.fetchStepCount()
-            missionComplete()
+            healthKitStore.fetchStepCount{ self.missionComplete() }
         }
         .padding(.horizontal, 20)
         .padding(.vertical, 20)
@@ -348,25 +352,17 @@ struct BehaviorMissionStyleView: View {
     
     func missionComplete() {
         if let stepCount = healthKitStore.stepCount {
-            if stepCount >= 1000 {
+            print("stepCount: \(stepCount)")
+            if stepCount >= 10 {
                 status1 = .complete
             }
             if stepCount >= 5000 {
-                status1 = .complete
+                status2 = .complete
             }
             if stepCount >= 10000 {
-                status1 = .complete
+                status3 = .complete
             }
         }
-//        if testStep >= 1000 {
-//            status1 = .complete
-//        }
-//        if testStep >= 5000 {
-//            status2 = .complete
-//        }
-//        if testStep >= 10000 {
-//            status3 = .complete
-//        }
     }
 }
 

--- a/Pickle/Pickle/Screen/Home/MissionView.swift
+++ b/Pickle/Pickle/Screen/Home/MissionView.swift
@@ -12,7 +12,6 @@ struct MissionView: View {
     var healthKitStore: HealthKitStore = HealthKitStore()
     @State private var showsAlert: Bool = false
     
-    // 각각의 미션별로 구분해줘야함
     @State private var timeStatus: Status = .ready
     @State private var behaviorStatus1: Status = .ready
     @State private var behaviorStatus2: Status = .ready
@@ -49,26 +48,26 @@ struct MissionView: View {
         .onAppear {
             // 시간 말고 날짜만 비교
             // 상태 초기화 후 날짜 다시 저장
-            Task {
-                let (_timeMissions, _behaviorMissions) = await missionStore.fetch()
-                timeMissions = _timeMissions
-                behaviorMissions = _behaviorMissions
-                
-                if timeMissions.isEmpty { return }
-                if behaviorMissions.isEmpty { return }
-                
-                if timeMissions[0].date.format("yyyy-mm-dd") != Date.now.format("yyyy-mm-dd") {
-                    missionStore.update(mission: .time(TimeMission(id: timeMissions[0].id,
-                                                                   title: timeMissions[0].title,
-                                                                   status: .ready,
-                                                                   date: Date.now,
-                                                                   wakeupTime: timeMissions[0].wakeupTime)))
-                    missionStore.update(mission: .behavior(BehaviorMission(id: behaviorMissions[0].id,
-                                                                           title: behaviorMissions[0].title,
-                                                                           status: .ready,
-                                                                           date: Date.now)))
-                }
-            }
+//            Task {
+//                let (_timeMissions, _behaviorMissions) = await missionStore.fetch()
+//                timeMissions = _timeMissions
+//                behaviorMissions = _behaviorMissions
+//                
+//                if timeMissions.isEmpty { return }
+//                if behaviorMissions.isEmpty { return }
+//                
+//                if timeMissions[0].date.format("yyyy-mm-dd") != Date.now.format("yyyy-mm-dd") {
+//                    missionStore.update(mission: .time(TimeMission(id: timeMissions[0].id,
+//                                                                   title: timeMissions[0].title,
+//                                                                   status: .ready,
+//                                                                   date: Date.now,
+//                                                                   wakeupTime: timeMissions[0].wakeupTime)))
+//                    missionStore.update(mission: .behavior(BehaviorMission(id: behaviorMissions[0].id,
+//                                                                           title: behaviorMissions[0].title,
+//                                                                           status: .ready,
+//                                                                           date: Date.now)))
+//                }
+//            }
         }
         .refreshable {
             healthKitStore.fetchStepCount()
@@ -90,7 +89,6 @@ struct MissionView_Previews: PreviewProvider {
         NavigationStack {
             MissionView()
                 .environmentObject(MissionStore())
-            // 프리뷰는 여기 있는 뷰만 로드하는 거니까 여기서 생성하지 않은 것들은 값을 넣어줘야함
         }
     }
 }

--- a/Pickle/Pickle/Screen/ViewModel/HealthKitStore.swift
+++ b/Pickle/Pickle/Screen/ViewModel/HealthKitStore.swift
@@ -21,7 +21,7 @@ class HealthKitStore {
         }
     }
     
-    func fetchStepCount() {
+    func fetchStepCount(_ completion: @escaping () -> Void = {}) {
         let calendar = Calendar.current
         let now = Date()
         let startOfDay = calendar.startOfDay(for: now)
@@ -35,6 +35,7 @@ class HealthKitStore {
                 let stepCount = Int(sum.doubleValue(for: HKUnit.count()))
                 DispatchQueue.main.async {
                     self.stepCount = stepCount
+                    completion()
                 }
             } else if let error = error {
                 print("걸음 수 가져오기 실패: \(error.localizedDescription)")


### PR DESCRIPTION
### 목적
걷기 미션에서 임의의 데이터로는 미션 완료 상태에 따라 버튼이 변경되지만 HealthKit를 적용하니까 걸음수가 받아와지지 않았습니다.

### 이유
미션 완료 조건 함수가 HealthKit에서 fetch해오는 속도보다 빠르기 때문

### 해결
- HealthKit
  fetch할 때 작업 완료 시점을 알기 위해서 completion을 escaping 클로저로 받아오도록 수정합니다.

- BehaviorMissionView
  미션 완료 조건 함수를 HealthKit의 fetch 함수의 인자로 넣어줍니다.

- MissionView
  인자가 없는 HealthKit fetch를 위해 fetch함수의 default 값을 빈 값으로 설정합니다.
  
### 기타 작업
- 기상 미션
  미션 완료 조건 함수 생성
- 기상 미션 시간 수정 뷰 디자인 변경