### PR TITLE
feat: Realm에 behaviorMission status 추가

### DIFF
--- a/Pickle/Pickle/Data/Extension/BehaviorMission-extension.swift
+++ b/Pickle/Pickle/Data/Extension/BehaviorMission-extension.swift
@@ -14,11 +14,15 @@ extension BehaviorMission {
         if let id = UUID(uuidString: self.id) {
             return BehaviorMissionObject(title: self.title,
                                          status: .init(rawValue: self.status.value) ?? .ready,
+                                         status1: .init(rawValue: self.status1.value) ?? .ready,
+                                         status2: .init(rawValue: self.status2.value) ?? .ready,
                                          date: self.date)
         } else {
             return BehaviorMissionObject(id: self.id,
                                          title: self.title,
                                          status: .init(rawValue: self.status.value) ?? .ready,
+                                         status1: .init(rawValue: self.status1.value) ?? .ready,
+                                         status2: .init(rawValue: self.status2.value) ?? .ready,
                                          date: self.date)
         }
     }
@@ -27,8 +31,8 @@ extension BehaviorMission {
         BehaviorMission(id: object.id.stringValue,
                         title: object.title,
                         status: .init(rawValue: object.status.rawValue) ?? .ready,
-                        status2: .init(rawValue: object.status.rawValue) ?? .ready,
-                        status3: .init(rawValue: object.status.rawValue) ?? .ready,
+                        status1: .init(rawValue: object.status1.rawValue) ?? .ready,
+                        status2: .init(rawValue: object.status2.rawValue) ?? .ready,
                         date: object.date)
     }
 }
@@ -38,8 +42,8 @@ extension BehaviorMission {
         BehaviorMission(id: self.id,
                         title: self.title,
                         status: status,
-                        status2: status,
-                        status3: status,
+                        status1: status1,
+                        status2: status2,
                         date: self.date)
     }
 }

--- a/Pickle/Pickle/Data/Model/Model/Mission.swift
+++ b/Pickle/Pickle/Data/Model/Model/Mission.swift
@@ -34,21 +34,21 @@ struct BehaviorMission: Mission, Identifiable {
     let id: String
     let title: String
     var status: MissionStatus
+    var status1: MissionStatus
     var status2: MissionStatus
-    var status3: MissionStatus
     var date: Date  // 투두 생성 날짜,시간
     
     init(id: String = UUID().uuidString,
          title: String = "",
          status: MissionStatus = .ready,
-         status2: MissionStatus,
-         status3: MissionStatus,
+         status1: MissionStatus = .ready,
+         status2: MissionStatus = .ready,
          date: Date = Date()) {
         self.id = id
         self.title = title
         self.status = status
+        self.status1 = status1
         self.status2 = status2
-        self.status3 = status3
         self.date = date
     }
 }

--- a/Pickle/Pickle/Data/Repository/Realm/Object/BehaviorMissionObject.swift
+++ b/Pickle/Pickle/Data/Repository/Realm/Object/BehaviorMissionObject.swift
@@ -12,21 +12,23 @@ class BehaviorMissionObject: Object, MissionObject, Identifiable {
     @Persisted(primaryKey: true) var id: ObjectId
     @Persisted var title: String
     @Persisted var status: TodoStatusPersisted
+    @Persisted var status1: TodoStatusPersisted
+    @Persisted var status2: TodoStatusPersisted
     @Persisted var date: Date  // 투두 생성 날짜,시간
     
     override class func primaryKey() -> String? {
         "id"
     }
     
-    convenience init(title: String, status: TodoStatusPersisted, date: Date) {
+    convenience init(title: String, status: TodoStatusPersisted, status1: TodoStatusPersisted, status2: TodoStatusPersisted, date: Date) {
         self.init()
         self.title = title
         self.status = status
         self.date = date
     }
     
-    convenience init(id: String, title: String, status: TodoStatusPersisted, date: Date) {
-        self.init(title: title, status: status, date: date)
+    convenience init(id: String, title: String, status: TodoStatusPersisted, status1: TodoStatusPersisted, status2: TodoStatusPersisted, date: Date) {
+        self.init(title: title, status: status, status1: status1, status2: status2, date: date)
         self.id = try! ObjectId(string: id)
     }
 }

--- a/Pickle/Pickle/Data/Repository/Repositories/Midiator.swift
+++ b/Pickle/Pickle/Data/Repository/Repositories/Midiator.swift
@@ -77,6 +77,3 @@ struct MissionMediator {
     //    func deleteAll()
     //    func update(model: DTO)
 }
-
-
-

--- a/Pickle/Pickle/Screen/App/ContentView.swift
+++ b/Pickle/Pickle/Screen/App/ContentView.swift
@@ -102,11 +102,11 @@ extension ContentView {
         let (t, b) = missionStore.fetch()
         if !t.isEmpty && !b.isEmpty { return }
         if t.isEmpty { 
-            let time = TimeMission(title: "기상 미션", status: .done, date: Date(), wakeupTime: Date())
+            let time = TimeMission(title: "기상 미션", status: .ready, date: Date(), wakeupTime: Date())
             missionStore.add(mission: .time(time))
         }
         if b.isEmpty {
-            let behavior = BehaviorMission(title: "걷기 미션", status: .ready, status2: .ready, status3: .ready, date: Date())
+            let behavior = BehaviorMission(title: "걷기 미션", status: .ready, status1: .ready, status2: .ready, date: Date())
             missionStore.add(mission: .behavior(behavior))
         }
     }

--- a/Pickle/Pickle/Screen/App/PickleApp.swift
+++ b/Pickle/Pickle/Screen/App/PickleApp.swift
@@ -82,7 +82,7 @@ struct PickleApp: App {
         Log.debug("dummy Delete called")
         userStore.deleteuserAll()
         missionStore.deleteAll(mission: .time(.init()))
-        missionStore.deleteAll(mission: .behavior(.init(status2: .complete, status3: .complete)))
+        missionStore.deleteAll(mission: .behavior(.init()))
         pizzaStore.deleteAll()
         Log.debug("dummy Delete end")
     }

--- a/Pickle/Pickle/Screen/Home/MissionView/MissionStyleView.swift
+++ b/Pickle/Pickle/Screen/Home/MissionView/MissionStyleView.swift
@@ -160,8 +160,8 @@ struct TimeMissionStyleView: View {
         .refreshable {
             missionComplet()
             print("timeMissionView")
-            print("mission: \(timeMission.date.format("yyyy-mm-dd"))")
-            print("Date: \(Date().format("yyyy-mm-dd"))")
+            print("mission: \(timeMission.date.format("yyyy-MM-dd"))")
+            print("Date: \(Date().format("yyyy-MM-dd"))")
             print("status: \(timeMission.status)")
         }
         .padding(.horizontal, 20)
@@ -180,7 +180,7 @@ struct TimeMissionStyleView: View {
         if Date() > timeMission.wakeupTime.adding(minutes: -10)
             && Date() < timeMission.wakeupTime.adding(minutes: 10)
             && timeMission.status == . ready {
-                timeMission.status = .complete
+            timeMission.status = .complete
         }
     }
 }
@@ -205,7 +205,7 @@ struct BehaviorMissionStyleView: View {
         }
     }
     var buttonSwitch2: Bool {
-        switch behaviorMission.status2 {
+        switch behaviorMission.status1 {
         case .ready, .done:
             return true
         case .complete:
@@ -215,7 +215,7 @@ struct BehaviorMissionStyleView: View {
         }
     }
     var buttonSwitch3: Bool {
-        switch behaviorMission.status3 {
+        switch behaviorMission.status2 {
         case .ready, .done:
             return true
         case .complete:
@@ -258,8 +258,8 @@ struct BehaviorMissionStyleView: View {
                         missionStore.update(mission: .behavior(BehaviorMission(id: behaviorMission.id,
                                                                                title: behaviorMission.title,
                                                                                status: .done,
+                                                                               status1: behaviorMission.status1,
                                                                                status2: behaviorMission.status2,
-                                                                               status3: behaviorMission.status3,
                                                                                date: behaviorMission.date)))
                         
                         withAnimation {
@@ -283,14 +283,14 @@ struct BehaviorMissionStyleView: View {
                         .bold()
                         .padding(.vertical, 3)
                     
-                    MissionButton(status: $behaviorMission.status2) {
-                        behaviorMission.status2 = .done
+                    MissionButton(status: $behaviorMission.status1) {
+                        behaviorMission.status1 = .done
                         
                         missionStore.update(mission: .behavior(BehaviorMission(id: behaviorMission.id,
                                                                                title: behaviorMission.title,
                                                                                status: behaviorMission.status,
-                                                                               status2: .done,
-                                                                               status3: behaviorMission.status3,
+                                                                               status1: .done,
+                                                                               status2: behaviorMission.status2,
                                                                                date: behaviorMission.date)))
                         withAnimation {
                             do {
@@ -313,14 +313,14 @@ struct BehaviorMissionStyleView: View {
                         .bold()
                         .padding(.vertical, 3)
                     
-                    MissionButton(status: $behaviorMission.status3) {
-                        behaviorMission.status3 = .done
+                    MissionButton(status: $behaviorMission.status2) {
+                        behaviorMission.status2 = .done
                         
                         missionStore.update(mission: .behavior(BehaviorMission(id: behaviorMission.id,
                                                                                title: behaviorMission.title,
                                                                                status: behaviorMission.status,
-                                                                               status2: behaviorMission.status2,
-                                                                               status3: .done,
+                                                                               status1: behaviorMission.status1,
+                                                                               status2: .done,
                                                                                date: behaviorMission.date)))
                         withAnimation {
                             do {
@@ -354,18 +354,17 @@ struct BehaviorMissionStyleView: View {
     
     func missionComplete() {
         if let stepCount = healthKitStore.stepCount {
-            if behaviorMission.status == .ready {
-                if stepCount >= 100 {
-                    behaviorMission.status = .complete
-                }
-                if stepCount >= 5000 {
-                    behaviorMission.status2 = .complete
-                }
-                if stepCount >= 10000 {
-                    behaviorMission.status3 = .complete
-                }
+            if behaviorMission.status == .ready && stepCount >= 1000 {
+                behaviorMission.status = .complete
+            }
+            if behaviorMission.status1 == .ready && stepCount >= 5000 {
+                behaviorMission.status1 = .complete
+            }
+            if behaviorMission.status2 == .ready && stepCount >= 10000 {
+                behaviorMission.status2 = .complete
             }
         }
+        
     }
 }
 
@@ -375,8 +374,8 @@ struct MissionStyle_Previews: PreviewProvider {
         BehaviorMissionStyleView(behaviorMission: .constant(BehaviorMission(id: "",
                                                                             title: "",
                                                                             status: .ready,
+                                                                            status1: .ready,
                                                                             status2: .ready,
-                                                                            status3: .ready,
                                                                             date: Date())),
                                  showsAlert: .constant(false),
                                  healthKitStore: HealthKitStore())

--- a/Pickle/Pickle/Screen/Home/MissionView/MissionView.swift
+++ b/Pickle/Pickle/Screen/Home/MissionView/MissionView.swift
@@ -16,7 +16,7 @@ struct MissionView: View {
         TimeMission(id: UUID().uuidString, title: "기상 미션", status: .done, date: Date(), wakeupTime: Date())
     ]
     @State private var behaviorMissions: [BehaviorMission] = [
-        BehaviorMission(id: UUID().uuidString, title: "걷기 미션", status: .ready, status2: .ready, status3: .ready, date: Date())
+        BehaviorMission(id: UUID().uuidString, title: "걷기 미션", status: .ready, status1: .ready, status2: .ready, date: Date())
     ]
     
     var body: some View {
@@ -36,8 +36,8 @@ struct MissionView: View {
         }
         .onAppear {
             print("onApear")
-            print("mission: \(timeMissions[0].date.format("yyyy-mm-dd"))")
-            print("Date: \(Date().format("yyyy-mm-dd"))")
+            print("mission: \(timeMissions[0].date.format("yyyy-MM-dd"))")
+            print("Date: \(Date().format("yyyy-MM-dd"))")
             print("status: \(timeMissions[0].status)")
             // 시간 말고 날짜만 비교
             // 상태 초기화 후 날짜 다시 저장
@@ -48,7 +48,7 @@ struct MissionView: View {
             if timeMissions.isEmpty { return }
             if behaviorMissions.isEmpty { return }
             
-            if timeMissions[0].date.format("yyyy-mm-dd") != Date().format("yyyy-mm-dd") {
+            if timeMissions[0].date.format("yyyy-MM-dd") != Date().format("yyyy-MM-dd") {
                 missionStore.update(mission: .time(TimeMission(id: timeMissions[0].id,
                                                                title: timeMissions[0].title,
                                                                status: .ready,
@@ -57,43 +57,43 @@ struct MissionView: View {
                 missionStore.update(mission: .behavior(BehaviorMission(id: behaviorMissions[0].id,
                                                                        title: behaviorMissions[0].title,
                                                                        status: .ready,
+                                                                       status1: .ready,
                                                                        status2: .ready,
-                                                                       status3: .ready,
                                                                        date: Date())))
             }
             missionStore.update(mission: .time(TimeMission(id: timeMissions[0].id,
                                                            title: timeMissions[0].title,
                                                            status: timeMissions[0].status,
-                                                           date: Date(),
+                                                           date: timeMissions[0].date,
                                                            wakeupTime: timeMissions[0].wakeupTime)))
             missionStore.update(mission: .behavior(BehaviorMission(id: behaviorMissions[0].id,
                                                                    title: behaviorMissions[0].title,
                                                                    status: behaviorMissions[0].status,
+                                                                   status1: behaviorMissions[0].status1,
                                                                    status2: behaviorMissions[0].status2,
-                                                                   status3: behaviorMissions[0].status3,
-                                                                   date: Date())))
+                                                                   date: behaviorMissions[0].date)))
         }
         .refreshable {
             print("refreshable")
-            print("mission: \(timeMissions[0].date.format("yyyy-mm-dd"))")
-            print("Date: \(Date().format("yyyy-mm-dd"))")
+            print("mission: \(timeMissions[0].date.format("yyyy-MM-dd"))")
+            print("Date: \(Date().format("yyyy-MM-dd"))")
             print("status: \(timeMissions[0].status)")
             missionStore.update(mission: .time(TimeMission(id: timeMissions[0].id,
                                                            title: timeMissions[0].title,
                                                            status: timeMissions[0].status,
-                                                           date: Date(),
+                                                           date: timeMissions[0].date,
                                                            wakeupTime: timeMissions[0].wakeupTime)))
             missionStore.update(mission: .behavior(BehaviorMission(id: behaviorMissions[0].id,
                                                                    title: behaviorMissions[0].title,
                                                                    status: behaviorMissions[0].status,
+                                                                   status1: behaviorMissions[0].status1,
                                                                    status2: behaviorMissions[0].status2,
-                                                                   status3: behaviorMissions[0].status3,
-                                                                   date: Date())))
+                                                                   date: behaviorMissions[0].date)))
         }
         .onDisappear {
             print("onDisappear")
-            print("mission: \(timeMissions[0].date.format("yyyy-mm-dd"))")
-            print("Date: \(Date().format("yyyy-mm-dd"))")
+            print("mission: \(timeMissions[0].date.format("yyyy-MM-dd"))")
+            print("Date: \(Date().format("yyyy-MM-dd"))")
             print("status: \(timeMissions[0].status)")
             missionStore.update(mission: .time(TimeMission(id: timeMissions[0].id,
                                                            title: timeMissions[0].title,
@@ -103,8 +103,8 @@ struct MissionView: View {
             missionStore.update(mission: .behavior(BehaviorMission(id: behaviorMissions[0].id,
                                                                    title: behaviorMissions[0].title,
                                                                    status: behaviorMissions[0].status,
+                                                                   status1: behaviorMissions[0].status1,
                                                                    status2: behaviorMissions[0].status2,
-                                                                   status3: behaviorMissions[0].status3,
                                                                    date: Date())))
         }
         .navigationTitle("미션")


### PR DESCRIPTION
### 목적
- 미션 상태가 조건에 맞지 않게 제각각 변경됨

### 이유
- 날짜 포멧에 따라 조건을 생성했는데 "월"을 추출해야하는데 "분"을 추출함
- Realm에 걷기 미션 상태에 대해 추가가 덜됐음

### 해결
- .format("yyyy-mm-dd") -> .format("yyyy-MM-dd")
- 걷기 미션에 필요한 상태들 Realm에 추가 적용