### PR TITLE
feat: 데일리 미션 초기화 오류 해결

### DIFF
--- a/Pickle/Pickle/Screen/Home/MissionView/MissionView.swift
+++ b/Pickle/Pickle/Screen/Home/MissionView/MissionView.swift
@@ -65,14 +65,14 @@ struct MissionView: View {
             missionStore.update(mission: .time(TimeMission(id: timeMissions[0].id,
                                                            title: timeMissions[0].title,
                                                            status: timeMissions[0].status,
-                                                           date: Date(),
+                                                           date: timeMissions[0].date,
                                                            wakeupTime: timeMissions[0].wakeupTime)))
             missionStore.update(mission: .behavior(BehaviorMission(id: behaviorMissions[0].id,
                                                                    title: behaviorMissions[0].title,
                                                                    status: behaviorMissions[0].status,
                                                                    status1: behaviorMissions[0].status1,
                                                                    status2: behaviorMissions[0].status2,
-                                                                   date: Date())))
+                                                                   date: behaviorMissions[0].date)))
         }
         .navigationTitle("미션")
         .navigationBarTitleDisplayMode(.inline)


### PR DESCRIPTION
### 목적
- 다음 날이 되면 미션이 준비되어야 하는데 안됨

### 이유
- 화면을 끌 때 변화된 내용그대로 업데이트에 넣어야하는데 현재 날짜를 업데이트함

### 해결방안
- 업데이트할때 date에 현재 날짜를 넣어주지 않음

### 내일 다시 해결됐는지 확인해야 한다