### PR TITLE
feat: 미션 성공 상태 데이터 업데이트

### DIFF
--- a/Pickle/Pickle/Screen/Home/MissionView/MissionStyleView.swift
+++ b/Pickle/Pickle/Screen/Home/MissionView/MissionStyleView.swift
@@ -159,10 +159,6 @@ struct TimeMissionStyleView: View {
         }
         .refreshable {
             missionComplete()
-            print("timeMissionView")
-            print("mission: \(timeMission.date.format("yyyy-MM-dd"))")
-            print("Date: \(Date().format("yyyy-MM-dd"))")
-            print("status: \(timeMission.status)")
         }
         .padding(.horizontal, 20)
         .padding(.vertical, 20)
@@ -372,16 +368,34 @@ struct BehaviorMissionStyleView: View {
             if behaviorMission.status != .done {
                 if stepCount >= 1000 {
                     behaviorMission.status = .complete
+                    missionStore.update(mission: .behavior(BehaviorMission(id: behaviorMission.id,
+                                                                           title: behaviorMission.title,
+                                                                           status: .complete,
+                                                                           status1: behaviorMission.status1,
+                                                                           status2: behaviorMission.status2,
+                                                                           date: behaviorMission.date)))
                 }
             }
             if behaviorMission.status1 != .done {
                 if stepCount >= 5000 {
                     behaviorMission.status1 = .complete
+                    missionStore.update(mission: .behavior(BehaviorMission(id: behaviorMission.id,
+                                                                           title: behaviorMission.title,
+                                                                           status: behaviorMission.status,
+                                                                           status1: .complete,
+                                                                           status2: behaviorMission.status2,
+                                                                           date: behaviorMission.date)))
                 }
             }
             if behaviorMission.status2 != .done {
                 if stepCount >= 10000 {
                     behaviorMission.status2 = .complete
+                    missionStore.update(mission: .behavior(BehaviorMission(id: behaviorMission.id,
+                                                                           title: behaviorMission.title,
+                                                                           status: behaviorMission.status,
+                                                                           status1: behaviorMission.status1,
+                                                                           status2: .complete,
+                                                                           date: behaviorMission.date)))
                 }
             }
         }


### PR DESCRIPTION
### 문제
- 미션 성공 상태 데이터 업데이트 해주지 않으면 미션뷰를 나갔다가 다시 들어오면 전의 내용이 fetch되어 피자 조각을 획득했었어도 다시 버튼이 활성화된다
### 해결
- 피자 조각을 획득하면 미션 상태를 .done으로 데이터에 업데이트 해준다