### PR TITLE
feat: 걷기 미션 버튼2, 3 refreshable시 상태가 update안되는 오류 해결

### DIFF
--- a/Pickle/Pickle/Data/Repository/Realm/Object/BehaviorMissionObject.swift
+++ b/Pickle/Pickle/Data/Repository/Realm/Object/BehaviorMissionObject.swift
@@ -24,6 +24,8 @@ class BehaviorMissionObject: Object, MissionObject, Identifiable {
         self.init()
         self.title = title
         self.status = status
+        self.status1 = status1
+        self.status2 = status2
         self.date = date
     }
     

--- a/Pickle/Pickle/Screen/Home/MissionView/MissionStyleView.swift
+++ b/Pickle/Pickle/Screen/Home/MissionView/MissionStyleView.swift
@@ -366,7 +366,7 @@ struct BehaviorMissionStyleView: View {
     func missionComplete() {
         if let stepCount = healthKitStore.stepCount {
             if behaviorMission.status != .done {
-                if stepCount >= 1000 {
+                if stepCount >= 1 {
                     behaviorMission.status = .complete
                     missionStore.update(mission: .behavior(BehaviorMission(id: behaviorMission.id,
                                                                            title: behaviorMission.title,
@@ -377,7 +377,7 @@ struct BehaviorMissionStyleView: View {
                 }
             }
             if behaviorMission.status1 != .done {
-                if stepCount >= 5000 {
+                if stepCount >= 7 {
                     behaviorMission.status1 = .complete
                     missionStore.update(mission: .behavior(BehaviorMission(id: behaviorMission.id,
                                                                            title: behaviorMission.title,
@@ -388,7 +388,7 @@ struct BehaviorMissionStyleView: View {
                 }
             }
             if behaviorMission.status2 != .done {
-                if stepCount >= 10000 {
+                if stepCount >= 8 {
                     behaviorMission.status2 = .complete
                     missionStore.update(mission: .behavior(BehaviorMission(id: behaviorMission.id,
                                                                            title: behaviorMission.title,

--- a/Pickle/Pickle/Screen/Home/MissionView/MissionView.swift
+++ b/Pickle/Pickle/Screen/Home/MissionView/MissionView.swift
@@ -38,7 +38,7 @@ struct MissionView: View {
             let (_timeMissions, _behaviorMissions) = missionStore.fetch()
             timeMissions = _timeMissions
             behaviorMissions = _behaviorMissions
-            print("onApear: \(timeMissions[0].status)")
+            print("onApear: \(behaviorMissions[0].status2)")
             
             if timeMissions.isEmpty { return }
             if behaviorMissions.isEmpty { return }
@@ -61,7 +61,7 @@ struct MissionView: View {
             let (_timeMissions, _behaviorMissions) = missionStore.fetch()
             timeMissions = _timeMissions
             behaviorMissions = _behaviorMissions
-            print("refreshable: \(timeMissions[0].status)")
+            print("refreshable: \(behaviorMissions[0].status2)")
         }
         .onDisappear {
             missionStore.update(mission: .time(TimeMission(id: timeMissions[0].id,
@@ -75,7 +75,7 @@ struct MissionView: View {
                                                                    status1: behaviorMissions[0].status1,
                                                                    status2: behaviorMissions[0].status2,
                                                                    date: behaviorMissions[0].date)))
-            print("onDisappear: \(timeMissions[0].status)")
+            print("onDisappear: \(behaviorMissions[0].status2)")
 
         }
         .navigationTitle("미션")


### PR DESCRIPTION
### 문제

-  refreshable할 때 버튼 2, 3 상태가 업데이트되지 않음

### 이유
- Realm에 버튼 2, 3 status 추가하지 않음

### 해결

- Realm에 status1, status2 추가