### PR TITLE
feat: 백그라운드 강제 언래핑 오류 해결

### DIFF
--- a/Pickle/Pickle/Screen/App/MySceneDelegate.swift
+++ b/Pickle/Pickle/Screen/App/MySceneDelegate.swift
@@ -10,8 +10,11 @@ import UIKit
 
 class MySceneDelegate: UIResponder, UIWindowSceneDelegate {
     func sceneDidEnterBackground(_ scene: UIScene) {
-        let appDelegate = UIApplication.shared.delegate as! AppDelegate
-        appDelegate.scheduleAppRefresh()
-        appDelegate.scheduleProcessingTaskIfNeeded()
+        if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
+            appDelegate.scheduleAppRefresh()
+            appDelegate.scheduleProcessingTaskIfNeeded()
+        } else {
+            print("AppDelegate를 찾을 수 없습니다.")
+        }
     }
 }


### PR DESCRIPTION
- 백그라운드 씬델리게이트에서 강제 언래핑으로 인한 오류 발견
- 오류 해결을 위해 옵셔널 바인딩을 이용해 앱델리게이트에 안전하게 접근