### PR TITLE
feat: 토스트에서 알럿으로 변경

### DIFF
--- a/Pickle/Pickle/Global/Common/Alert/CompleteAlert.swift
+++ b/Pickle/Pickle/Global/Common/Alert/CompleteAlert.swift
@@ -78,16 +78,25 @@ struct CompleteAlert: View {
     
     var body: some View {
         VStack(spacing: 22) {
+            Button {
+                isPresented = false
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: 20))
+                    .hTrailing()
+                    .foregroundColor(.black)
+            }
+            
             Image(pizzaName)
                 .resizable()
                 .aspectRatio(contentMode: .fit)
                 .frame(width: CGFloat.screenWidth * 0.5)
-                .padding(.top, 20)
             
             Text(title)
                 .font(.title)
                 .bold()
                 .foregroundColor(.black)
+            
             
             Text("\(contents) 완성")
                 .font(.pizzaBody)
@@ -111,6 +120,6 @@ struct CompleteAlert: View {
                 isPresented: .constant(true),
                 pizzaName: "smilePizza",
                 title: "축하합니다",
-            contents: "포테이토")
+                contents: "포테이토")
         )
 }

--- a/Pickle/Pickle/Screen/Home/HomeView/View/HomeView.swift
+++ b/Pickle/Pickle/Screen/Home/HomeView/View/HomeView.swift
@@ -113,9 +113,9 @@ struct HomeView: View {
     private func pizza_8_successAction(user: User) {
         if user.currentPizzaSlice % 8 == 0 {
             navigationStore.pushHomeView(home: .showCompleteAlert(true))
-            DispatchQueue.main.asyncAfter(deadline: .now() + 4) {
-                navigationStore.dismiss(home: .showCompleteAlert(false))
-            }
+//            DispatchQueue.main.asyncAfter(deadline: .now() + 4) {
+//                navigationStore.dismiss(home: .showCompleteAlert(false))
+//            }
         }
     }
     


### PR DESCRIPTION
### 🎋 작업중인 브랜치
- feat/alert

### 💡 작업동기
- 토스트 메세지보다 명확하게 완성된 모습을 알럿으로 보여주기

### 🔑 주요 변경사항
- 피자 한판이 완성되고 4초 후 저절로 꺼지지 않도록 변경
- xmark를 누르거나 배경을 터치하면 사라지도록 변경
