### PR TITLE
fix: 피자조각 에러 해결, 타이머뷰 기기대응 완료

### DIFF
--- a/Pickle/Pickle/Screen/Calendar/CalendarView.swift
+++ b/Pickle/Pickle/Screen/Calendar/CalendarView.swift
@@ -143,6 +143,7 @@ struct CalendarView: View {
                     .buttonBorderShape(.roundedRectangle(radius: 50))
                 }
                 weekHeaderView()
+                    .padding(.top,5)
                 
                 if weekToMonth { monthlyView() }
                 else { weekView(calendarModel.currentWeek)

--- a/Pickle/Pickle/Screen/Calendar/TaskRowView.swift
+++ b/Pickle/Pickle/Screen/Calendar/TaskRowView.swift
@@ -19,7 +19,7 @@ struct TaskRowView: View {
         case .done:
             return .pickle
         case .giveUp:
-            return .red
+            return .gray
         default:
             return .pickle
         }

--- a/Pickle/Pickle/Screen/Home/TimerView/TimerReportView.swift
+++ b/Pickle/Pickle/Screen/Home/TimerView/TimerReportView.swift
@@ -99,31 +99,31 @@ struct TimerReportView: View {
                 
             }
             
-            Button(action: {
-                if todo.status == .done{
-                    do {
-                        try userStore.addPizzaSlice(slice: 1)
-                    } catch {
-                        Log.error("❌피자 조각 추가 실패❌")
-                    }
-                }
-  
-                
-                timerVM.timerVMreset()
-                dismiss()
-                isShowingTimerView.toggle()
-                
-            }, label: {
-                Text("확인")
-                    .font(.pizzaBody)
-                    .bold()
-                    .padding(.vertical, 8)
-                    .frame(width: .screenWidth * 0.2)
-                    .foregroundColor(.white)
-            })
-            .buttonStyle(.borderedProminent)
-            .tint(.pickle)
-            .padding(.bottom, .screenWidth * 0.1)
+                Button(action: {
+//                    if todo.status == .done {
+//                        do {
+//                            try userStore.addPizzaSlice(slice: 1)
+//                        } catch {
+//                            Log.error("❌피자 조각 추가 실패❌")
+//                        }
+//                    }
+                    
+                    timerVM.timerVMreset()
+                    dismiss()
+                    isShowingTimerView.toggle()
+                    
+                }, label: {
+                    Text("확인")
+                        .font(.pizzaBody)
+                        .bold()
+                        .padding(.vertical, 8)
+                        .frame(width: .screenWidth * 0.2)
+                        .foregroundColor(.white)
+                })
+                .buttonStyle(.borderedProminent)
+                .tint(.pickle)
+                .padding(.bottom, .screenWidth * 0.1)
+            
         }
         .onAppear {
             timeFormat = is24HourClock ? "HH:mm" : "a h:mm"

--- a/Pickle/Pickle/Screen/Home/TimerView/TimerView.swift
+++ b/Pickle/Pickle/Screen/Home/TimerView/TimerView.swift
@@ -44,8 +44,11 @@ struct TimerView: View {
     var body: some View {
         ZStack {
             VStack {
+                
                 timerTitleView
-                Spacer()
+                    .offset(y: -(.screenWidth * 0.80))
+              
+//                Spacer()
             }
             
             // MARK: 타이머 부분
@@ -65,6 +68,7 @@ struct TimerView: View {
                     wiseSayingView
                 }
             }
+            .offset(y: .screenWidth * 0.08 )
         }
         .onAppear {
             startTodo()
@@ -149,9 +153,15 @@ struct TimerView: View {
         print("isRunTimer:\(isRunTimer)")
         backgroundNumber = 0
         
+        do {
+            try userStore.addPizzaSlice(slice: 1)
+        } catch {
+            Log.error("❌피자 조각 추가 실패❌")
+        }
+        
         print("done: spendTime:\(spendTime) targetTime:\(todo.targetTime)")
         if spendTime < todo.targetTime {
-//            todoStore.deleteNotification(todo: todo, notificationManager: notificationManager)
+            todoStore.deleteNotificaton(todo: todo, noti: notificationManager)
             print("노티 삭제~")
         }
         
@@ -248,9 +258,9 @@ extension TimerView {
                         .lineLimit(1)
                         .padding(.horizontal, 10)
                     
-                    Text("🍕가 구워지고 있어요")
-                        .font(.pizzaBody)
-                        .foregroundColor(.secondary)
+//                    Text("🍕가 구워지고 있어요")
+//                        .font(.pizzaBody)
+//                        .foregroundColor(.secondary)
                 }
             }
         }
@@ -339,11 +349,14 @@ extension TimerView {
     var timerButtonView: some View {
         HStack {
             // 완료 버튼
+            
             Button {
                 print("완료시 spendTime:\(timerVM.spendTime)")
                 isComplete = true
                 updateDone(spendTime: timerVM.spendTime)
+            
                 isShowingReportSheet = true
+
             } label: {
                 Text("완료")
                     .font(.pizzaHeadline)

--- a/Pickle/Pickle/Screen/Model/Model/Todo.swift
+++ b/Pickle/Pickle/Screen/Model/Model/Todo.swift
@@ -76,7 +76,7 @@ extension Todo {
               startTime: Date(),
               targetTime: 0,
               spendTime: 10,
-              status: .ready)
+              status: .giveUp)
     }
 }
 


### PR DESCRIPTION
fix: 피자조각 에러 해결, 타이머뷰 기기대응 완료

### 🎋 작업중인 브랜치
- feature/calendar/1120

### 💡 작업동기
- 피자 갯수 오류( 확인버튼 누르면 피자자동생성 오류)
- 타이머뷰 기기대응( iPhone SE)
- 
### 🔑 주요 변경사항
- 피자 갯수 -> updateDone에서 피자 조각 +1 처리
- 타이머뷰 UI -> .offset으로 모두 처리

### 🏞 스크린샷
스크린샷을 첨부해주세요.

### 관련 이슈
- #193 
