### PR TITLE
fix: 할일 시작 후 시작알림 오류 해결

### DIFF
--- a/Pickle/Pickle/Screen/Home/HomeView/Component/TodoCellView.swift
+++ b/Pickle/Pickle/Screen/Home/HomeView/Component/TodoCellView.swift
@@ -14,6 +14,8 @@ struct TodoCellView: View {
     
     @Environment(\.colorScheme) var colorScheme
     @EnvironmentObject var navigationStore: NavigationStore
+    @EnvironmentObject var todoStore: TodoStore
+    @EnvironmentObject var notificationManager: NotificationManager
     
     var todo: Todo
     
@@ -38,6 +40,8 @@ struct TodoCellView: View {
                 
                 Button {
                     navigationStore.pushHomeView(home: .isShowingTimerView(todo))
+                    todoStore.deleteNotificaton(todo: todo, noti: notificationManager)
+                    
                 } label: {
                     ZStack {
                         Rectangle()


### PR DESCRIPTION
### 🎋 작업중인 브랜치
- 작업 중인 브랜치를 알려주세요.

### 💡 작업동기
- 할일 등록 후 -> 할일 바로 실행 -> 타이머뷰 진입 -> 타이머 카운트 중 -> 시작하라는 알림이 옴

### 🔑 주요 변경사항
- HomeView 시작버튼 누르면 해당 Todo 시작알림 삭제

### 🏞 스크린샷
스크린샷을 첨부해주세요.

### 관련 이슈
- #197 
