### PR TITLE
Hotfix/timer/giveup alert

### DIFF
--- a/Pickle/Pickle/Data/Repository/Repositories/TimeMissionRepository.swift
+++ b/Pickle/Pickle/Data/Repository/Repositories/TimeMissionRepository.swift
@@ -48,6 +48,7 @@ final class TimeMissionRepository: BaseRepository<TimeMissionObject>, TimeReposi
             return results
         } catch {
             assert(false)
+            Log.error(error.localizedDescription)
         }
         return []
     }

--- a/Pickle/Pickle/Global/Common/Alert/GiveupAlert.swift
+++ b/Pickle/Pickle/Global/Common/Alert/GiveupAlert.swift
@@ -16,7 +16,8 @@ extension View {
         primaryAction: @escaping (Double) -> Void,
         primaryparameter: TimeInterval,
         secondaryButton: String,
-        secondaryAction: @escaping () -> Void
+        secondaryAction: @escaping () -> Void,
+        externalTapAction: (() -> Void)? = nil
     ) -> some View {
         return modifier(
             GiveupAlertModifier(isPresented: isPresented,
@@ -26,13 +27,15 @@ extension View {
                                 primaryAction: primaryAction, 
                                 primaryparameter: primaryparameter,
                                 secondaryButton: secondaryButton,
-                                secondaryAction: secondaryAction)
+                                secondaryAction: secondaryAction, 
+                                externalAction: externalTapAction)
         )
     }
 }
 
 struct GiveupAlertModifier: ViewModifier {
     
+    @Environment(\.dismiss) var dissmiss
     @Binding var isPresented: Bool
     
     let title: String
@@ -42,6 +45,7 @@ struct GiveupAlertModifier: ViewModifier {
     let primaryparameter: TimeInterval
     let secondaryButton: String
     let secondaryAction: () -> Void
+    let externalAction: (() -> Void)?
     
     func body(content: Content) -> some View {
         ZStack {
@@ -53,8 +57,12 @@ struct GiveupAlertModifier: ViewModifier {
                         .ignoresSafeArea()
                         .onTapGesture {
                             self.isPresented = false // 외부 영역 터치 시 내려감
+                            if let externalAction {
+                                externalAction()
+                            } else {
+                                dissmiss()
+                            }
                         }
-                    
                     GiveupAlert(isPresented: $isPresented,
                                 title: title,
                                 contents: contents,
@@ -157,5 +165,6 @@ struct GiveupAlert: View {
                                       primaryAction: { _ in }, 
                                       primaryparameter: 20,
                                       secondaryButton: "돌아가기",
-                                      secondaryAction: { }))
+                                      secondaryAction: { }, 
+                                      externalAction: { }))
 }

--- a/Pickle/Pickle/Global/Dependency/Injected/DependencyContainer.swift
+++ b/Pickle/Pickle/Global/Dependency/Injected/DependencyContainer.swift
@@ -44,6 +44,7 @@ struct DependencyContainer {
                     return service
                 }
             }
+            Log.error("fattalError singleton Occur")
             assert(false, "fattalError singleton Occur")
         case .newSingleton:
             let service = factories[serviceName]?() as? Dependency
@@ -51,11 +52,13 @@ struct DependencyContainer {
                 cache[serviceName] = service
                 return service
             }
+            Log.error("fattalError singleton Occur")
             assert(false, "fattalError singleton Occur")
         case .new, .automatic:
             if let dependency = factories[serviceName]?() as? Dependency {
                 return dependency
             }
+            Log.error("fattalError singleton Occur")
             assert(false, "fattalError singleton Occur")
         }
         return nil

--- a/Pickle/Pickle/Screen/Home/TimerView/TimerView.swift
+++ b/Pickle/Pickle/Screen/Home/TimerView/TimerView.swift
@@ -91,7 +91,8 @@ struct TimerView: View {
                          primaryAction: updateGiveup,
                          primaryparameter: timerVM.spendTime,
                          secondaryButton: "돌아가기",
-                         secondaryAction: giveupSecondary)
+                         secondaryAction: giveupSecondary,
+                         externalTapAction: giveupSecondary)
     }
     
     func giveupSecondary() {
@@ -237,6 +238,7 @@ struct TimerView: View {
             }
         }
     }
+
 }
 
 extension TimerView {

--- a/Pickle/Pickle/Screen/Model/Store/MissionStore.swift
+++ b/Pickle/Pickle/Screen/Model/Store/MissionStore.swift
@@ -102,6 +102,7 @@ final class MissionStore: ObservableObject {
             }
         } catch {
             assert(false)
+            Log.error("MissonStore: func observe - catch error")
         }
     }
     

--- a/Pickle/Pickle/Screen/Model/Store/TodoStore.swift
+++ b/Pickle/Pickle/Screen/Model/Store/TodoStore.swift
@@ -28,6 +28,7 @@ final class TodoStore: ObservableObject {
             return todo
         } else {
             assert(false, "getSeleted Todo Failed")
+            Log.error("getSeleted Todo Failed")
         }
         return Todo.sample
     }


### PR DESCRIPTION
### 🎋 작업중인 브랜치
- hotfix/timer/giveupAlert

### 💡 작업동기
- alert바깥을 눌렀을 때 타이머가 멈추는 이슈를 해결하기 위해

### 🔑 주요 변경사항
- giveupAlert에 externalTapAction을 추가해서 alert바깥을 터치해도 취소랑 같은 작업을 하도록 해결

### 관련 이슈
- #212 
